### PR TITLE
Be able to use a config file and decouple the lib from the PIM

### DIFF
--- a/src/Akeneo/CouplingDetector/Configuration/Configuration.php
+++ b/src/Akeneo/CouplingDetector/Configuration/Configuration.php
@@ -2,7 +2,7 @@
 
 namespace Akeneo\CouplingDetector\Configuration;
 
-use Akeneo\CouplingDetector\Data\RuleInterface;
+use Akeneo\CouplingDetector\Domain\RuleInterface;
 use Symfony\Component\Finder\Finder;
 
 /**
@@ -22,11 +22,15 @@ class Configuration
     /**
      * Configuration constructor.
      *
-     * @param Finder          $finder
      * @param RuleInterface[] $rules
+     * @param Finder          $finder
      */
-    public function __construct(Finder $finder, array $rules)
+    public function __construct(array $rules, Finder $finder = null)
     {
+        if (null === $finder) {
+            $finder = new DefaultFinder();
+        }
+
         $this->finder = $finder;
         $this->rules = $rules;
     }

--- a/src/Akeneo/CouplingDetector/Configuration/Configuration.php
+++ b/src/Akeneo/CouplingDetector/Configuration/Configuration.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Akeneo\CouplingDetector\Configuration;
+
+use Akeneo\CouplingDetector\Data\RuleInterface;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Configuration DTO that will be used by the detect command.
+ *
+ * @author  Julien Janvier <j.janvier@gmail.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+class Configuration
+{
+    /** @var RuleInterface[] */
+    private $rules;
+
+    /** @var Finder */
+    private $finder;
+
+    /**
+     * Configuration constructor.
+     *
+     * @param Finder          $finder
+     * @param RuleInterface[] $rules
+     */
+    public function __construct(Finder $finder, array $rules)
+    {
+        $this->finder = $finder;
+        $this->rules = $rules;
+    }
+
+    /**
+     * @return RuleInterface[]
+     */
+    public function getRules()
+    {
+        return $this->rules;
+    }
+
+    /**
+     * @return Finder
+     */
+    public function getFinder()
+    {
+        return $this->finder;
+    }
+}

--- a/src/Akeneo/CouplingDetector/Configuration/DefaultFinder.php
+++ b/src/Akeneo/CouplingDetector/Configuration/DefaultFinder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Akeneo\CouplingDetector\Configuration;
+
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Default finder implementation
+ *
+ * @author  Julien Janvier <j.janvier@gmail.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+class DefaultFinder extends Finder
+{
+    /**
+     * DefaultFinder constructor.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->files()
+            ->name('*.php')
+            ->ignoreDotFiles(true)
+            ->ignoreVCS(true)
+            ->exclude('vendor')
+        ;
+    }
+}

--- a/src/Akeneo/CouplingDetector/Configuration/examples/akeneo_pim-community-dev.php_cd
+++ b/src/Akeneo/CouplingDetector/Configuration/examples/akeneo_pim-community-dev.php_cd
@@ -1,15 +1,12 @@
 <?php
 
+use \Akeneo\CouplingDetector\Configuration\DefaultFinder;
 use \Akeneo\CouplingDetector\Configuration\Configuration;
 use \Akeneo\CouplingDetector\Data\Rule;
 use \Akeneo\CouplingDetector\Data\RuleInterface;
-use \Symfony\Component\Finder\Finder;
 
-$finder = new Finder();
-$finder
-    ->files()
-    ->name('*.php')
-    ->notPath('Oro');
+$finder = new DefaultFinder();
+$finder->notPath('Oro');
 
 $rules = [
     new Rule(
@@ -260,6 +257,6 @@ $legacyExclusions = [
     ],
 ];
 
-$config = new Configuration($finder, $rules);
+$config = new Configuration($rules, $finder);
 
 return $config;

--- a/src/Akeneo/CouplingDetector/Configuration/examples/akeneo_pim-community-dev.php_cd
+++ b/src/Akeneo/CouplingDetector/Configuration/examples/akeneo_pim-community-dev.php_cd
@@ -1,0 +1,265 @@
+<?php
+
+use \Akeneo\CouplingDetector\Configuration\Configuration;
+use \Akeneo\CouplingDetector\Data\Rule;
+use \Akeneo\CouplingDetector\Data\RuleInterface;
+use \Symfony\Component\Finder\Finder;
+
+$finder = new Finder();
+$finder
+    ->files()
+    ->name('*.php')
+    ->notPath('Oro');
+
+$rules = [
+    new Rule(
+        'Akeneo\Component',
+        ['Pim', 'PimEnterprise', 'Bundle', 'Doctrine\ORM'],
+        RuleInterface::TYPE_FORBIDDEN
+    ),
+    new Rule(
+        'Akeneo\Bundle',
+        ['Pim', 'PimEnterprise'],
+        RuleInterface::TYPE_FORBIDDEN
+    ),
+    new Rule(
+        'Pim\Component',
+        ['PimEnterprise', 'Bundle', 'Doctrine\ORM'],
+        RuleInterface::TYPE_FORBIDDEN
+    ),
+    new Rule(
+        'Pim\Bundle',
+        ['PimEnterprise'],
+        RuleInterface::TYPE_FORBIDDEN
+    ),
+    new Rule(
+        'Pim\Bundle\CatalogBundle',
+        [
+            // bundles
+            'AnalyticsBundle',
+            'CommentBundle',
+            'DataGridBundle',
+            'ImportExportBundle',
+            'LocalizationBundle',
+            'PdfGeneratorBundle',
+            'TranslationBundle',
+            'VersioningBundle',
+            'BaseConnectorBundle',
+            'ConnectorBundle',
+            'EnrichBundle',
+            'InstallerBundle',
+            'NavigationBundle',
+            'ReferenceDataBundle',
+            'UIBundle',
+            'WebServiceBundle',
+            'DashboardBundle',
+            'FilterBundle',
+            'JsFormValidationBundle',
+            'NotificationBundle',
+            'TransformBundle',
+            'UserBundle',
+            'BatchBundle',
+            // components
+            'Connector',
+        ],
+        RuleInterface::TYPE_FORBIDDEN
+    ),
+    new Rule(
+        'Pim\Bundle\ConnectorBundle',
+        [
+            'AnalyticsBundle',
+            'CommentBundle',
+            'DataGridBundle',
+            'ImportExportBundle',
+            'LocalizationBundle',
+            'PdfGeneratorBundle',
+            'TranslationBundle',
+            'VersioningBundle',
+            'BaseConnectorBundle',
+            'CatalogBundle',
+            'EnrichBundle',
+            'InstallerBundle',
+            'NavigationBundle',
+            'ReferenceDataBundle',
+            'UIBundle',
+            'WebServiceBundle',
+            'DashboardBundle',
+            'FilterBundle',
+            'JsFormValidationBundle',
+            'NotificationBundle',
+            'TransformBundle',
+            'UserBundle',
+        ],
+        RuleInterface::TYPE_FORBIDDEN
+    ),
+];
+
+$legacyExclusions = [
+    // TranslatableInterface should be moved in a Akeneo component
+    'Akeneo\Component\Classification\Updater\CategoryUpdater'   => [
+        'Pim\Bundle\TranslationBundle\Entity\TranslatableInterface',
+    ],
+    // Repository interfaces should never expose QueryBuilder as parameter
+    'Akeneo\Component\Classification\Repository'                => [
+        'Doctrine\ORM\QueryBuilder',
+    ],
+    'Pim\Component\Catalog'                                     => [
+        // Model interfaces of CatalogBundle should be extracted in the catalog component
+        'Pim\Bundle\CatalogBundle\Model\ChannelInterface',
+        'Pim\Bundle\CatalogBundle\Model\LocaleInterface',
+        'Pim\Bundle\CatalogBundle\Model\ProductValueInterface',
+        'Pim\Bundle\CatalogBundle\Model\AttributeInterface',
+        'Pim\Bundle\CatalogBundle\Model\ProductInterface',
+        'Pim\Bundle\CatalogBundle\Model\AttributeOptionInterface',
+        'Pim\Bundle\CatalogBundle\Model\AssociationInterface',
+        'Pim\Bundle\CatalogBundle\Model\CategoryInterface',
+        'Pim\Bundle\CatalogBundle\Model\FamilyInterface',
+        'Pim\Bundle\CatalogBundle\Model\AttributeGroupInterface',
+        'Pim\Bundle\CatalogBundle\Model\GroupInterface',
+        'Pim\Bundle\CatalogBundle\Model\AssociationTypeInterface',
+        'Pim\Bundle\CatalogBundle\Model\ProductTemplateInterface',
+        'Pim\Bundle\CatalogBundle\Model\AttributeRequirementInterface',
+        // Repository interfaces of CatalogBundle should be extracted in the catalog component
+        'Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\ChannelRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\GroupTypeRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\LocaleRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\AttributeGroupRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\AttributeRequirementRepositoryInterface',
+        // Builder interface should be extracted in the catalog component
+        'Pim\Bundle\CatalogBundle\Builder\ProductBuilderInterface',
+        // Extract at least an interface of these factories in the catalog component (ideally move implem too)
+        'Pim\Bundle\CatalogBundle\Factory\FamilyFactory',
+        'Pim\Bundle\CatalogBundle\Factory\AttributeRequirementFactory',
+        'Pim\Bundle\CatalogBundle\Factory\MetricFactory',
+        // What to do with this class?
+        'Pim\Bundle\CatalogBundle\Validator\AttributeValidatorHelper',
+        // Extract this exception in the component, it should be more accurate than InvalidArgumentException
+        // as it looks only used in updaters
+        'Pim\Bundle\CatalogBundle\Exception\InvalidArgumentException',
+        // Avoid to use this manager, extract an interface from this or maybe use repository and depreciate it
+        'Pim\Bundle\CatalogBundle\Manager\CurrencyManager',
+        // What to do with this, cannot be extracted due to dependencies to symfony form
+        'Pim\Bundle\CatalogBundle\AttributeType\AbstractAttributeType',
+        'Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes',
+        // Deprecated in 1.5, should be dropped the deprecated methods support
+        'Pim\Bundle\CatalogBundle\Updater\ProductUpdaterInterface',
+    ],
+    'Pim\Component\Connector'                                   => [
+        // Interfaces of BatchBundle should be extracted in an Akeneo component
+        'Akeneo\Bundle\BatchBundle\Entity\StepExecution',
+        'Akeneo\Bundle\BatchBundle\Entity\JobExecution',
+        'Akeneo\Bundle\BatchBundle\Item\InvalidItemException',
+        'Akeneo\Bundle\BatchBundle\Item\ItemProcessorInterface',
+        'Akeneo\Bundle\BatchBundle\Item\ItemReaderInterface',
+        'Akeneo\Bundle\BatchBundle\Item\UploadedFileAwareInterface',
+        'Akeneo\Bundle\BatchBundle\Item\AbstractConfigurableStepElement',
+        'Akeneo\Bundle\BatchBundle\Item\ItemWriterInterface',
+        'Akeneo\Bundle\BatchBundle\Job\RuntimeErrorException',
+        'Akeneo\Bundle\BatchBundle\Step\AbstractStep',
+        'Akeneo\Bundle\BatchBundle\Step\StepExecutionAwareInterface',
+        // Model interfaces of CatalogBundle should be extracted in the catalog component
+        'Pim\Bundle\CatalogBundle\Model\ProductInterface',
+        'Pim\Bundle\CatalogBundle\Model\AttributeInterface',
+        'Pim\Bundle\CatalogBundle\Model\AssociationTypeInterface',
+        'Pim\Bundle\CatalogBundle\Model\FamilyInterface',
+        'Pim\Bundle\CatalogBundle\Model\GroupInterface',
+        'Pim\Bundle\CatalogBundle\Model\AttributeOptionInterface',
+        'Pim\Bundle\CatalogBundle\Model\ProductValueInterface',
+        // Repositories interfaces of CatalogBundle should be extracted in the catalog component
+        'Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\LocaleRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\CurrencyRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\GroupTypeRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\AssociationTypeRepositoryInterface',
+        'Pim\Bundle\CatalogBundle\Repository\ChannelRepositoryInterface',
+        // What to do with this, cannot be extracted due to dependencies to symfony form
+        'Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes',
+        'Pim\Bundle\CatalogBundle\AttributeType\AbstractAttributeType',
+        // We need to check why we use these classes, interfaces should be extracted in the catalog component
+        'Pim\Bundle\CatalogBundle\Manager\AttributeValuesResolver',
+        'Pim\Bundle\CatalogBundle\Manager\ProductTemplateApplierInterface',
+        'Pim\Bundle\CatalogBundle\Validator\Constraints\File',
+        // For factories and builders of CatalogBundle, interfaces should be created in the catalog component
+        'Pim\Bundle\CatalogBundle\Builder\ProductBuilderInterface',
+        'Pim\Bundle\CatalogBundle\Factory\AttributeFactory',
+        'Pim\Bundle\CatalogBundle\Factory\AssociationTypeFactory',
+        'Pim\Bundle\CatalogBundle\Factory\FamilyFactory',
+        'Pim\Bundle\CatalogBundle\Factory\GroupFactory',
+        // Version manager should be exploded with SRP and introduce different interfaces in a component
+        'Pim\Bundle\VersioningBundle\Manager\VersionManager',
+    ],
+    // Connector component should not rely on base connector file writer, move the implementation in BC manner
+    'Pim\Component\Connector\Writer\File\YamlWriter'            => [
+        'Pim\Bundle\BaseConnectorBundle\Writer\File\FileWriter',
+    ],
+    // Same issues than catalog component updater classes, same fixes expected
+    'Pim\Component\ReferenceData\Updater'                       => [
+        'Pim\Bundle\CatalogBundle\Builder\ProductBuilderInterface',
+        'Pim\Bundle\CatalogBundle\Model\AttributeInterface',
+        'Pim\Bundle\CatalogBundle\Model\ProductInterface',
+        'Pim\Bundle\CatalogBundle\Model\ProductValueInterface',
+        'Pim\Bundle\CatalogBundle\Validator\AttributeValidatorHelper',
+        'Pim\Bundle\CatalogBundle\Exception\InvalidArgumentException',
+    ],
+    // Same issues than catalog component updater classes, same fixes expected
+    'Pim\Component\Localization'                                => [
+        'Pim\Bundle\CatalogBundle\Model\MetricInterface',
+        'Pim\Bundle\CatalogBundle\Model\ProductPriceInterface',
+        'Pim\Bundle\CatalogBundle\Model\ProductValueInterface',
+        'Pim\Bundle\CatalogBundle\AttributeType\AttributeTypes',
+        'Pim\Bundle\CatalogBundle\Repository\AttributeRepositoryInterface',
+        // Why we use it?
+        'Pim\Component\Localization\Normalizer\MetricNormalizer',
+    ],
+    'Pim\Bundle\CatalogBundle\Model'                            => [
+        // should be extracted in a component in a akeneo component in a BC way (localization?)
+        'Pim\Bundle\TranslationBundle\Entity\TranslatableInterface',
+        'Pim\Bundle\TranslationBundle\Entity\AbstractTranslation',
+        // should be extracted in a akeneo component in a BC way
+        'Pim\Bundle\VersioningBundle\Model\VersionableInterface',
+        // should be extracted in a akeneo component in a BC way
+        'Pim\Bundle\CommentBundle\Model\CommentSubjectInterface',
+    ],
+    'Pim\Bundle\CatalogBundle\Entity'                           => [
+        // should be extracted in a component in a akeneo component in a BC way (localization?)
+        'Pim\Bundle\TranslationBundle\Entity\TranslatableInterface',
+        'Pim\Bundle\TranslationBundle\Entity\AbstractTranslation',
+        // should be extracted in a akeneo component in a BC way
+        'Pim\Bundle\VersioningBundle\Model\VersionableInterface',
+    ],
+    'Pim\Bundle\CatalogBundle\EventSubscriber'                  => [
+        // should be extracted in a akeneo component in a BC way
+        'Pim\Bundle\VersioningBundle\Model\VersionableInterface',
+    ],
+    'Pim\Bundle\CatalogBundle\Doctrine\Common\Saver\GroupSaver' => [
+        // what to do with this, it's a weird way to share and update versionning context, could be re-worked
+        // with the versioning reworking (no more relying on doctrine events)
+        'Pim\Bundle\VersioningBundle\Manager\VersionContext',
+    ],
+    'Pim\Bundle\CatalogBundle\Manager\FamilyManager'            => [
+        // FamilyManager should be dropped and not even used
+        'Pim\Bundle\UserBundle\Context\UserContext',
+    ],
+    'Pim\Bundle\CatalogBundle\Helper\LocaleHelper'              => [
+        // LocaleHelper should be simplified and moved to LocalizationBundle
+        'Pim\Bundle\UserBundle\Context\UserContext',
+    ],
+    'Pim\Bundle\CatalogBundle\Repository'                       => [
+        // CatalogBundle repository interfaces should not rely on an EnrichBundle DataTransformer interface,
+        // this enrich interface is not even related to UI and should be moved
+        'Pim\Bundle\EnrichBundle\Form\DataTransformer\ChoicesProviderInterface',
+        // CatalogBundle repository interfaces should not rely on a UIBundle repository interface, this ui
+        // interface should be moved
+        'Pim\Bundle\UIBundle\Entity\Repository\OptionRepositoryInterface',
+    ],
+    // CatalogBundle MongoDB normalizers should not use a TransformBundle normalizer, will be better to
+    // duplicate code or extract
+    'Pim\Bundle\CatalogBundle\MongoDB\Normalizer'               => [
+        'Pim\Bundle\TransformBundle\Normalizer\Structured\TranslationNormalizer',
+    ],
+];
+
+$config = new Configuration($finder, $rules);
+
+return $config;

--- a/src/Akeneo/CouplingDetector/Console/Application.php
+++ b/src/Akeneo/CouplingDetector/Console/Application.php
@@ -2,7 +2,7 @@
 
 namespace Akeneo\CouplingDetector\Console;
 
-use Akeneo\CouplingDetector\Console\Command\PimCommunityCommand;
+use Akeneo\CouplingDetector\Console\Command\DetectCommand;
 use Akeneo\CouplingDetector\CouplingDetector;
 use Symfony\Component\Console\Application as BaseApplication;
 
@@ -20,6 +20,6 @@ class Application extends BaseApplication
     {
         error_reporting(-1);
         parent::__construct('Akeneo coupling detector', CouplingDetector::VERSION);
-        $this->add(new PimCommunityCommand());
+        $this->add(new DetectCommand());
     }
 }

--- a/src/Akeneo/CouplingDetector/Console/Application.php
+++ b/src/Akeneo/CouplingDetector/Console/Application.php
@@ -3,6 +3,7 @@
 namespace Akeneo\CouplingDetector\Console;
 
 use Akeneo\CouplingDetector\Console\Command\PimCommunityCommand;
+use Akeneo\CouplingDetector\CouplingDetector;
 use Symfony\Component\Console\Application as BaseApplication;
 
 /**
@@ -18,7 +19,7 @@ class Application extends BaseApplication
     public function __construct()
     {
         error_reporting(-1);
-        parent::__construct('Akeneo coupling detector');
+        parent::__construct('Akeneo coupling detector', CouplingDetector::VERSION);
         $this->add(new PimCommunityCommand());
     }
 }

--- a/src/Akeneo/CouplingDetector/Console/Command/DetectCommand.php
+++ b/src/Akeneo/CouplingDetector/Console/Command/DetectCommand.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Akeneo\CouplingDetector\Console\Command;
+
+use Akeneo\CouplingDetector\Configuration\Configuration;
+use Akeneo\CouplingDetector\CouplingDetector;
+use Akeneo\CouplingDetector\Data\RuleInterface;
+use Akeneo\CouplingDetector\Data\ViolationInterface;
+use Akeneo\CouplingDetector\NodeExtractor\NodeExtractorResolver;
+use Akeneo\CouplingDetector\RuleChecker;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Detects the coupling issues.
+ *
+ * @author    Nicolas Dupont <nicolas@akeneo.com>
+ * @copyright 2015 Akeneo SAS (http://www.akeneo.com)
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+class DetectCommand extends Command
+{
+    /**
+     * {@inheritedDoc}.
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('detect')
+            ->setDefinition(
+                [
+                    new InputArgument('path', InputArgument::OPTIONAL, 'path of the project', null),
+                    new InputOption(
+                        'config-file',
+                        null,
+                        InputOption::VALUE_REQUIRED,
+                        'file path of the configuration file'
+                    ),
+                    new InputOption(
+                        'output',
+                        null,
+                        InputOption::VALUE_REQUIRED, 'Output mode, "default", "none"',
+                        'default'
+                    ),
+                    new InputOption(
+                        'strict',
+                        null,
+                        InputOption::VALUE_NONE,
+                        'Apply strict rules without legacy exceptions'
+                    ),
+                ]
+            )
+            ->setDescription('Detect coupling violations')
+            ->setHelp(
+                <<<HELP
+The <info>%command.name%</info> command detects coupling problems for a given file or directory depending on the
+coupling rules that have been defined:
+    <info>php %command.full_name% /path/to/dir</info>
+    <info>php %command.full_name% /path/to/file</info>
+
+You can save the configuration in a <comment>.php_cd</comment> file in the root directory of
+your project. The file must return an instance of ``Akeneo\CouplingDetector\Configuration\Configuration``,
+which lets you configure the rules and the directories that need to be analyzed.
+Here is an example below:
+    <?php
+    use \Akeneo\CouplingDetector\Data\Rule;
+    use \Akeneo\CouplingDetector\Data\RuleInterface;
+
+    $finder = new \Symfony\Component\Finder\Finder();
+    $finder
+        ->files()
+        ->name('*.php')
+        ->notPath('foo/bar/');
+
+    $rules = [
+        new Rule('foo', ['bar', 'baz'], RuleInterface::TYPE_FORBIDDEN),
+        new Rule('zoo', ['too'], RuleInterface::TYPE_DISCOURAGED),
+        new Rule('bli', ['bla', 'ble', 'blu'], RuleInterface::TYPE_ONLY),
+    ];
+
+    return new \Akeneo\CouplingDetector\Configuration\Configuration($rules, $finder);
+    ?>
+
+You can also use the default finder implementation if you want to analyse all the PHP files
+of your directory:
+    <?php
+    use \Akeneo\CouplingDetector\Data\Rule;
+    use \Akeneo\CouplingDetector\Data\RuleInterface;
+
+    $rules = [
+        new Rule('foo', ['bar', 'baz'], RuleInterface::TYPE_FORBIDDEN),
+        new Rule('zoo', ['too'], RuleInterface::TYPE_DISCOURAGED),
+        new Rule('bli', ['bla', 'ble', 'blu'], RuleInterface::TYPE_ONLY),
+    ];
+
+    return new \Akeneo\CouplingDetector\Configuration\Configuration(
+        $rules,
+        \Akeneo\CouplingDetector\Configuration\DefaultFinder
+    );
+    ?>
+
+With the <comment>--config-file</comment> option you can specify the path to the <comment>.php_cd</comment> file:
+    <info>php %command.full_name% /path/to/dir --config-file=/path/to/my/configuration.php_cd</info>
+HELP
+            )
+        ;
+    }
+
+    /**
+     * {@inheritedDoc}.
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if (null !== $path = $input->getArgument('path')) {
+            $filesystem = new Filesystem();
+            if (!$filesystem->isAbsolutePath($path)) {
+                $path = getcwd() . DIRECTORY_SEPARATOR . $path;
+            }
+        }
+
+        if (null === $configFile = $input->getOption('config-file')) {
+            $configDir = $path;
+            if (is_file($path) && $dirName = pathinfo($path, PATHINFO_DIRNAME)) {
+                $configDir = $dirName;
+            } elseif (null === $path) {
+                $configDir = getcwd();
+                // path is directory
+            }
+            $configFile = $configDir . DIRECTORY_SEPARATOR . '.php_cd';
+        }
+
+        $config = $this->loadConfiguration($configFile);
+
+        $strictMode = $input->getOption('strict');
+        $displayMode = $input->getOption('output');
+
+        if ('none' !== $displayMode) {
+            $output->writeln(
+                sprintf(
+                    '<info> Detect coupling violations (strict mode %s)</info>',
+                    $strictMode ? 'enabled' : 'disabled'
+                )
+            );
+        }
+
+        $rules = $config->getRules();
+        $finder = $config->getFinder();
+        $finder->in($path);
+
+        $nodeExtractorResolver = new NodeExtractorResolver();
+        $ruleChecker = new RuleChecker();
+        $detector = new CouplingDetector($nodeExtractorResolver, $ruleChecker);
+
+        $violations = $detector->detect($finder, $rules);
+
+        if ('none' !== $displayMode) {
+            $this->displayStandardViolations($output, $violations);
+        }
+
+        return count($violations) > 0 ? 1 : 0;
+    }
+
+    /**
+     * @param OutputInterface      $output
+     * @param ViolationInterface[] $violations
+     */
+    protected function displayStandardViolations(OutputInterface $output, array $violations)
+    {
+        $totalCount = 0;
+        foreach ($violations as $violation) {
+            $rule = $violation->getRule();
+            $node = $violation->getNode();
+            $errorType = RuleInterface::TYPE_DISCOURAGED === $rule->getType() ? 'warning' : 'error';
+
+            $output->writeln('');
+            $output->writeln(sprintf('Rule "%s" violated in file "%s"', $rule->getSubject(), $node->getFilepath()));
+            foreach ($violation->getTokenViolations() as $token) {
+                $output->writeln(sprintf('<%s> - use %s</%s>', $errorType, $token, $errorType));
+            }
+            $totalCount += count($violation->getTokenViolations());
+        }
+        $output->writeln(sprintf('<info>Total coupling issues: %d.</info>', $totalCount));
+    }
+
+    /**
+     * @param string $filePath
+     *
+     * @return Configuration
+     */
+    protected function loadConfiguration($filePath)
+    {
+        if (!is_file($filePath)) {
+            throw new \InvalidArgumentException(sprintf('The configuration file "%s" does not exit', $filePath));
+        }
+
+        $config = include $filePath;
+
+        if (!$config instanceof Configuration) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'The configuration file "%s" must return a "Akeneo\CouplingDetector\Configuration\Configuration"',
+                    $filePath
+                )
+            );
+        }
+
+        return $config;
+    }
+}

--- a/src/Akeneo/CouplingDetector/CouplingDetector.php
+++ b/src/Akeneo/CouplingDetector/CouplingDetector.php
@@ -16,6 +16,8 @@ use Symfony\Component\Finder\Finder;
  */
 class CouplingDetector
 {
+    const VERSION = 'master';
+
     /** @var NodeParserResolver */
     private $nodeExtractorResolver;
 
@@ -67,8 +69,8 @@ class CouplingDetector
     {
         $nodes = [];
         foreach ($finder as $file) {
-            $extractor = $this->nodeExtractorResolver->resolve($file);
-            $nodes[] = $extractor->parse($file);
+            $parser = $this->nodeExtractorResolver->resolve($file);
+            $nodes[] = $parser->parse($file);
         }
 
         return $nodes;


### PR DESCRIPTION
TODO:
- [x] decouple lib from the PIM 
- [x] be able to use a config file specified in the command line 
- [x] be able to use a config file `.php_cd` from the project root path
- [x] default finder implementation for php files
- [x] be able to create a configuration with the default finder
- [x] fill in the help of the `detect` command
- [ ] remove `display` mode of the `detect` command?

Fixes https://github.com/nidup/php-coupling-detector/issues/5

To merge after https://github.com/nidup/php-coupling-detector/pull/4
